### PR TITLE
[Feat/feed] 피드 추가 구현

### DIFF
--- a/Projects/Common/Sources/Common/StickyImageView.swift
+++ b/Projects/Common/Sources/Common/StickyImageView.swift
@@ -1,0 +1,27 @@
+//
+//  StickyImageView.swift
+//  Common
+//
+//  Created by 유현진 on 6/26/24.
+//
+
+import UIKit
+import Kingfisher
+
+public class StickyImageView: UIImageView {
+    
+    public override init(frame: CGRect) {
+        super.init(frame: frame)
+        self.contentMode = .scaleAspectFill
+        self.clipsToBounds = true
+        self.backgroundColor = UIColor.lightGray // 이미지 로딩 중 표시할 색상 설정
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    func setImage(url: URL) {
+        self.kf.setImage(with: url, placeholder: nil, options: [.transition(.fade(0.2))]) // Kingfisher를 사용하여 이미지 설정
+    }
+}

--- a/Projects/Coordinator/Sources/Coordinator/AppCoordinator.swift
+++ b/Projects/Coordinator/Sources/Coordinator/AppCoordinator.swift
@@ -23,6 +23,7 @@ public class AppCoordinator: Coordinator{
     public func start() {
         AuthManager.shared.isValidAccessToken()
             .bind{ bool in
+                print(UserDefaults.standard.object(forKey: "accessToken"))
                 if bool{
                     self.showBaseTabBarController()
                 }else{

--- a/Projects/Coordinator/Sources/Coordinator/Feed/FeedCoordinator.swift
+++ b/Projects/Coordinator/Sources/Coordinator/Feed/FeedCoordinator.swift
@@ -27,13 +27,20 @@ class FeedCoordinator: Coordinator{
 }
 
 extension FeedCoordinator: FeedCoordinatorInterface{
-    func showFeedDetail(postId: Int) {
+    func showFeedDetail(viewController: FeedViewController, postId: Int) {
         let vc = feedDIContainer.makeFeedDetailViewController(postId: postId, coordinator: self)
+        vc.delegate = viewController
         self.navigationController.pushViewController(vc, animated: true)
     }
     
     func showReportComment(commentId: Int) {
         let vc = feedDIContainer.makeReportCommentViewController(commentId: commentId, coordinator: self)
+        self.navigationController.pushViewController(vc, animated: true)
+    }
+    
+    func showEditPost(viewController: FeedDetailViewController, postId: Int){
+        let vc = feedDIContainer.makeEditPostViewController(postId: postId, coordinator: self)
+        vc.delegate = viewController
         self.navigationController.pushViewController(vc, animated: true)
     }
 }

--- a/Projects/Coordinator/Sources/DIContainer/Feed/FeedDIContainer.swift
+++ b/Projects/Coordinator/Sources/DIContainer/Feed/FeedDIContainer.swift
@@ -36,7 +36,12 @@ class FeedDIContainer{
     func makeReportCommentViewController(commentId: Int, coordinator: FeedCoordinator) -> ReportCommentViewController{
         let feedUseCase = feedUseCase
         let vc = ReportCommentViewController(reactor: ReportCommentReactor(feedUsecase: feedUseCase, commentId: commentId))
-        
+        return vc
+    }
+    
+    func makeEditPostViewController(postId: Int, coordinator: FeedCoordinator) -> EditFeedViewController{
+        let feedUseCase = feedUseCase
+        let vc = EditFeedViewController(reactor: EditFeedReactor(feedUsecase: feedUseCase, postId: postId))
         return vc
     }
 }

--- a/Projects/Data/Sources/Network/Feed/FeedService.swift
+++ b/Projects/Data/Sources/Network/Feed/FeedService.swift
@@ -13,7 +13,7 @@ import Domain
 public enum FeedService{
     case fetchFeeds(page: Int, size: Int = 10)
     case fetchPost(postId: Int)
-    case fetchComment(postId: Int, page: Int, size: Int = 10)
+    case fetchComment(postId: Int)
     case writeComment(commentModel: WriteCommentReqesutDTO)
     case makeBookmark(post: BookmarkRequestDTO)
     case deleteBookmark(postId: Int)
@@ -80,8 +80,8 @@ extension FeedService: TargetType{
         switch self{
         case .fetchFeeds(let page, let size):
             return .requestParameters(parameters: ["page" : page + 1, "size" : size, "sort" : "recommended", "distance" : 100], encoding: URLEncoding.queryString)
-        case .fetchComment(let postId, let page, let size):
-            return .requestParameters(parameters: ["page" : page + 1, "size" : size, "postNo" : postId], encoding: URLEncoding.queryString)
+        case .fetchComment(let postId):
+            return .requestParameters(parameters: ["postNo" : postId], encoding: URLEncoding.queryString)
         case .reportComment(let reportCommentModel):
             return .requestJSONEncodable(reportCommentModel)
         case .editPost(_, let editPostModel):

--- a/Projects/Data/Sources/Network/Feed/FeedService.swift
+++ b/Projects/Data/Sources/Network/Feed/FeedService.swift
@@ -19,6 +19,8 @@ public enum FeedService{
     case deleteBookmark(postId: Int)
     case deleteComment(postId: Int)
     case reportComment(reportCommentModel: ReportCommentRequestDTO)
+    case deletePost(postId: Int)
+    case editPost(postId: Int, editPostModel: EditFeedRequestDTO)
 }
 
 extension FeedService: TargetType{
@@ -48,6 +50,10 @@ extension FeedService: TargetType{
             return "/reply/delete/\(postId)"
         case .reportComment:
             return "/reply-reports"
+        case .deletePost(let postId):
+            return "/posts/\(postId)"
+        case .editPost(let postId, _):
+            return "/posts/\(postId)"
         }
     }
     
@@ -61,9 +67,11 @@ extension FeedService: TargetType{
                 .makeBookmark,
                 .reportComment:
             return .post
-        case .deleteBookmark:
+        case .deleteBookmark,
+                .deletePost:
             return .delete
-        case .deleteComment:
+        case .deleteComment,
+                .editPost:
             return .put
         }
     }
@@ -76,10 +84,12 @@ extension FeedService: TargetType{
             return .requestParameters(parameters: ["page" : page + 1, "size" : size, "postNo" : postId], encoding: URLEncoding.queryString)
         case .reportComment(let reportCommentModel):
             return .requestJSONEncodable(reportCommentModel)
-            
+        case .editPost(_, let editPostModel):
+            return .requestJSONEncodable(editPostModel)
         case .fetchPost,
                 .deleteBookmark,
-                .deleteComment:
+                .deleteComment,
+                .deletePost:
             return .requestPlain
         case .writeComment(let commentModel):
             return .requestJSONEncodable(commentModel)
@@ -97,10 +107,11 @@ extension FeedService: TargetType{
                 .makeBookmark,
                 .deleteBookmark,
                 .deleteComment,
-                .reportComment:
+                .reportComment,
+                .deletePost,
+                .editPost:
             return ["Content-type": "application/json",
                     "Authorization": accessToken]
-        
         }
     }
 }

--- a/Projects/Data/Sources/Repositories/Feed/FeedRepositoryFeedRepositoryImplementation.swift
+++ b/Projects/Data/Sources/Repositories/Feed/FeedRepositoryFeedRepositoryImplementation.swift
@@ -44,12 +44,12 @@ public final class FeedRepositoryImplementation: FeedRepositoryProtocol{
             }
     }
     
-    public func fetchComment(postId: Int, page: Int, size: Int = 10) -> Observable<([CommentModel], Int)> {
-        return service.rx.request(.fetchComment(postId: postId, page: page))
+    public func fetchComment(postId: Int) -> Observable<[CommentModel]> {
+        return service.rx.request(.fetchComment(postId: postId))
             .filterSuccessfulStatusCodes()
-            .map{ response -> ([CommentModel], Int) in
+            .map{ response -> [CommentModel] in
                 let commentReponse = try JSONDecoder().decode(CommentsResponseDTO.self, from: response.data)
-                return (commentReponse.data.content, commentReponse.data.totalPages)
+                return commentReponse.data.content
             }.asObservable()
             .catch{ error in
                 print("FeedRepositoryImplementation fetchComment error = \(error)")

--- a/Projects/Data/Sources/Repositories/Feed/FeedRepositoryFeedRepositoryImplementation.swift
+++ b/Projects/Data/Sources/Repositories/Feed/FeedRepositoryFeedRepositoryImplementation.swift
@@ -102,4 +102,20 @@ public final class FeedRepositoryImplementation: FeedRepositoryProtocol{
                 return Observable.just(())
             }.asObservable()
     }
+    
+    public func deletePost(postId: Int) -> Observable<Any> {
+        return service.rx.request(.deletePost(postId: postId))
+            .filterSuccessfulStatusCodes()
+            .map{ _ in
+                return Observable.just(())
+            }.asObservable()
+    }
+    
+    public func editPost(postId: Int, editPostModel: EditFeedRequestDTO) -> Observable<Any> {
+        return service.rx.request(.editPost(postId: postId, editPostModel: editPostModel))
+            .filterSuccessfulStatusCodes()
+            .map{ _ in
+                return Observable.just(())
+            }.asObservable()
+    }
 }

--- a/Projects/Domain/Sources/Entities/Feed/Feed/FeedResponseDTO.swift
+++ b/Projects/Domain/Sources/Entities/Feed/Feed/FeedResponseDTO.swift
@@ -31,7 +31,7 @@ public struct FeedResponseData: Decodable{
 }
 
 public struct FeedModel: Decodable{
-    public let postNo: Int
+    public let postId: Int
     public let nickname: String?
     public let createDate: String?
     public let postContent: String
@@ -41,10 +41,10 @@ public struct FeedModel: Decodable{
     public let imageUrl: String?
     public let commentCount: Int
     public let likeCount: Int
-    public let isBookmarked: Bool
+    public var isBookmarked: Bool
     
     enum CodingKeys: String, CodingKey {
-        case postNo
+        case postId = "postNo"
         case nickname
         case createDate
         case postContent

--- a/Projects/Domain/Sources/Entities/Feed/FeedDetail/Request/EditFeedRequestDTO.swift
+++ b/Projects/Domain/Sources/Entities/Feed/FeedDetail/Request/EditFeedRequestDTO.swift
@@ -1,0 +1,23 @@
+//
+//  EditFeedRequestDTO.swift
+//  Domain
+//
+//  Created by 유현진 on 6/26/24.
+//
+
+import Foundation
+//    0: 거리
+//    1: 시간
+//    2: 칼로리
+//    3: 평균페이스
+public struct EditFeedRequestDTO: Codable{
+    let postContent: String
+    let mainData: Int
+    let difficulty: String
+    
+    public init(postContent: String, dataType: Int, difficulty: String) {
+        self.postContent = postContent
+        self.mainData = dataType
+        self.difficulty = difficulty
+    }
+}

--- a/Projects/Domain/Sources/Entities/Feed/FeedDetail/Request/EditFeedRequestDTO.swift
+++ b/Projects/Domain/Sources/Entities/Feed/FeedDetail/Request/EditFeedRequestDTO.swift
@@ -13,11 +13,11 @@ import Foundation
 public struct EditFeedRequestDTO: Codable{
     let postContent: String
     let mainData: Int
-    let difficulty: String
+    let imageUrl: String
     
-    public init(postContent: String, dataType: Int, difficulty: String) {
+    public init(postContent: String, dataType: Int, imageUrl: String) {
         self.postContent = postContent
         self.mainData = dataType
-        self.difficulty = difficulty
+        self.imageUrl = imageUrl
     }
 }

--- a/Projects/Domain/Sources/Entities/Feed/FeedDetail/Response/CommentsResponseDTO.swift
+++ b/Projects/Domain/Sources/Entities/Feed/FeedDetail/Response/CommentsResponseDTO.swift
@@ -23,13 +23,9 @@ public struct CommentsResponseDTO: Decodable{
 
 public struct CommentsResponseData: Decodable{
     public let content: [CommentModel]
-    public let pageNumber: Int
-    public let totalPages: Int
     
     enum CodingKeys: CodingKey {
         case content
-        case pageNumber
-        case totalPages
     }
 }
 
@@ -44,8 +40,6 @@ public struct CommentModel: Decodable{
     public let createDate: String
     public let isUpdated: Bool
     public let isOwner: Bool
-    //"parentReplyNo": null,
-    //"children": [],
     
     enum CodingKeys: String, CodingKey {
         case commentId = "replyNo"

--- a/Projects/Domain/Sources/Entities/Feed/FeedDetail/Response/CommentsResponseDTO.swift
+++ b/Projects/Domain/Sources/Entities/Feed/FeedDetail/Response/CommentsResponseDTO.swift
@@ -43,7 +43,7 @@ public struct CommentModel: Decodable{
     public let isDeleted: Bool
     public let createDate: String
     public let isUpdated: Bool
-    public let isOwner: Bool?
+    public let isOwner: Bool
     //"parentReplyNo": null,
     //"children": [],
     

--- a/Projects/Domain/Sources/Entities/Feed/FeedDetail/Response/FeedDetailResponseDTO.swift
+++ b/Projects/Domain/Sources/Entities/Feed/FeedDetail/Response/FeedDetailResponseDTO.swift
@@ -36,6 +36,7 @@ public struct FeedDetailModel: Decodable{
     public let createDate: String
     public var commentCount: Int
     public var likeCount: Int
+    public let isOwner: Bool
     
     enum CodingKeys: String, CodingKey {
         case nickname
@@ -52,5 +53,6 @@ public struct FeedDetailModel: Decodable{
         case createDate
         case likeCount = "likeCnt"
         case commentCount = "replyCnt"
+        case isOwner = "owner"
     }
 }

--- a/Projects/Domain/Sources/Entities/Feed/FeedDetail/Response/FeedDetailResponseDTO.swift
+++ b/Projects/Domain/Sources/Entities/Feed/FeedDetail/Response/FeedDetailResponseDTO.swift
@@ -29,9 +29,9 @@ public struct FeedDetailModel: Decodable{
     public let role: String
     public let loactionName: String?
     public let distance: Float
-    public let time: Float
-    public let meanPace: Float
-    public let kcal: Float
+    public let time: Int
+    public let meanPace: Int
+    public let kcal: Int
     public let imageUrl: String?
     public let createDate: String
     public var commentCount: Int

--- a/Projects/Domain/Sources/Entities/Feed/FeedDetail/Response/FeedDetailResponseDTO.swift
+++ b/Projects/Domain/Sources/Entities/Feed/FeedDetail/Response/FeedDetailResponseDTO.swift
@@ -23,7 +23,7 @@ public struct FeedDetailResponseDTO: Decodable{
 
 public struct FeedDetailModel: Decodable{
     public let nickname: String?
-    public let profileImagUrl: String?
+    public let profileImageUrl: String?
     public let level: Int
     public let postContent: String
     public let role: String
@@ -40,7 +40,7 @@ public struct FeedDetailModel: Decodable{
     
     enum CodingKeys: String, CodingKey {
         case nickname
-        case profileImagUrl
+        case profileImageUrl
         case level
         case postContent
         case role

--- a/Projects/Domain/Sources/Repository Interface/FeedRepositoryProtocol.swift
+++ b/Projects/Domain/Sources/Repository Interface/FeedRepositoryProtocol.swift
@@ -18,4 +18,6 @@ public protocol FeedRepositoryProtocol{
     func deleteBookmark(postId: Int) -> Observable<Any>
     func deleteComment(postId: Int) -> Observable<Any>
     func reportComment(reportCommentModel: ReportCommentRequestDTO) -> Observable<Any>
+    func deletePost(postId: Int) -> Observable<Any>
+    func editPost(postId: Int, editPostModel: EditFeedRequestDTO) -> Observable<Any>
 }

--- a/Projects/Domain/Sources/Repository Interface/FeedRepositoryProtocol.swift
+++ b/Projects/Domain/Sources/Repository Interface/FeedRepositoryProtocol.swift
@@ -12,7 +12,7 @@ import RxSwift
 public protocol FeedRepositoryProtocol{
     func fetchFeeds(page: Int) -> Observable<([FeedModel], Int)>
     func fetchPost(postId: Int) -> Observable<FeedDetailModel>
-    func fetchComment(postId: Int, page: Int, size: Int) -> Observable<([CommentModel], Int)>
+    func fetchComment(postId: Int) -> Observable<[CommentModel]>
     func writeComment(commentModel: WriteCommentReqesutDTO) -> Observable<WriteCommentResponseModel>
     func makeBookmark(post: BookmarkRequestDTO) -> Observable<Any>
     func deleteBookmark(postId: Int) -> Observable<Any>

--- a/Projects/Domain/Sources/UseCases/FeedUseCase.swift
+++ b/Projects/Domain/Sources/UseCases/FeedUseCase.swift
@@ -24,8 +24,8 @@ public final class FeedUseCase: FeedUseCaseProtocol{
         return repository.fetchPost(postId: postId)
     }
     
-    public func fetchComment(postId: Int, page: Int, size: Int = 10) -> Observable<([CommentModel], Int)> {
-        return  repository.fetchComment(postId: postId, page: page, size: size)
+    public func fetchComment(postId: Int) -> Observable<[CommentModel]> {
+        return  repository.fetchComment(postId: postId)
     }
     
     public func writeComment(commentModel: WriteCommentReqesutDTO) -> Observable<WriteCommentResponseModel> {

--- a/Projects/Domain/Sources/UseCases/FeedUseCase.swift
+++ b/Projects/Domain/Sources/UseCases/FeedUseCase.swift
@@ -47,4 +47,12 @@ public final class FeedUseCase: FeedUseCaseProtocol{
     public func reportComment(reportCommentModel: ReportCommentRequestDTO) -> Observable<Any> {
         return repository.reportComment(reportCommentModel: reportCommentModel)
     }
+    
+    public func deletePost(postId: Int) -> Observable<Any> {
+        return repository.deletePost(postId: postId)
+    }
+    
+    public func editPost(postId: Int, editPostModel: EditFeedRequestDTO) -> Observable<Any> {
+        return repository.editPost(postId: postId, editPostModel: editPostModel)
+    }
 }

--- a/Projects/Domain/Sources/UseCases/Protocol/FeedUseCaseProtocol.swift
+++ b/Projects/Domain/Sources/UseCases/Protocol/FeedUseCaseProtocol.swift
@@ -11,7 +11,7 @@ import RxSwift
 protocol FeedUseCaseProtocol{
     func fetchFeeds(page: Int) -> Observable<([FeedModel], Int)>
     func fetchPost(postId: Int) -> Observable<FeedDetailModel>
-    func fetchComment(postId: Int, page: Int, size: Int) -> Observable<([CommentModel], Int)>
+    func fetchComment(postId: Int) -> Observable<[CommentModel]>
     func writeComment(commentModel: WriteCommentReqesutDTO) -> Observable<WriteCommentResponseModel>
     func makeBookmark(post: BookmarkRequestDTO) -> Observable<Any>
     func deleteBookmark(postId: Int) -> Observable<Any>

--- a/Projects/Domain/Sources/UseCases/Protocol/FeedUseCaseProtocol.swift
+++ b/Projects/Domain/Sources/UseCases/Protocol/FeedUseCaseProtocol.swift
@@ -17,4 +17,6 @@ protocol FeedUseCaseProtocol{
     func deleteBookmark(postId: Int) -> Observable<Any>
     func deleteComment(postId: Int) -> Observable<Any>
     func reportComment(reportCommentModel: ReportCommentRequestDTO) -> Observable<Any>
+    func deletePost(postId: Int) -> Observable<Any>
+    func editPost(postId: Int, editPostModel: EditFeedRequestDTO) -> Observable<Any>
 }

--- a/Projects/Presentation/Sources/Feed/CoordinatorInterface/FeedCoordinatorInterface.swift
+++ b/Projects/Presentation/Sources/Feed/CoordinatorInterface/FeedCoordinatorInterface.swift
@@ -8,6 +8,7 @@
 import Foundation
 
 public protocol FeedCoordinatorInterface{
-    func showFeedDetail(postId: Int)
+    func showFeedDetail(viewController: FeedViewController, postId: Int)
     func showReportComment(commentId: Int)
+    func showEditPost(viewController: FeedDetailViewController, postId: Int)
 }

--- a/Projects/Presentation/Sources/Feed/Edit Feed/Reactor/EditFeedReactor.swift
+++ b/Projects/Presentation/Sources/Feed/Edit Feed/Reactor/EditFeedReactor.swift
@@ -1,0 +1,56 @@
+//
+//  EditFeedReactor.swift
+//  Presentation
+//
+//  Created by 유현진 on 6/26/24.
+//
+
+import Foundation
+import ReactorKit
+import Domain
+
+public class EditFeedReactor: Reactor{
+    
+    public enum Action{
+        case fetchPost
+        case editfeed(EditFeedRequestDTO)
+    }
+    
+    public enum Mutation{
+        case setFeedModel(FeedDetailModel)
+        case setEditedFeed(Bool)
+    }
+    
+    public struct State{
+        let postId: Int
+        var feed: FeedDetailModel?
+        var editedFeed: Bool = false
+    }
+    
+    public var initialState: State
+    private let feedUsecase: FeedUseCase
+    public init(feedUsecase: FeedUseCase, postId: Int) {
+        self.initialState = State(postId: postId)
+        self.feedUsecase = feedUsecase
+    }
+    
+    public func mutate(action: Action) -> Observable<Mutation> {
+        switch action{
+        case .fetchPost:
+            return feedUsecase.fetchPost(postId: currentState.postId).map{ Mutation.setFeedModel($0) }
+        case .editfeed(let model):
+            return feedUsecase.editPost(postId: currentState.postId, editPostModel: model).map{ _ in Mutation.setEditedFeed(true) }
+        }
+    }
+    
+    public func reduce(state: State, mutation: Mutation) -> State {
+        var newState = state
+        switch mutation{
+        case .setFeedModel(let model):
+            newState.feed = model
+        case .setEditedFeed(let value):
+            newState.editedFeed = value
+        }
+        return newState
+    }
+}

--- a/Projects/Presentation/Sources/Feed/Edit Feed/View Controller/EditFeedViewController.swift
+++ b/Projects/Presentation/Sources/Feed/Edit Feed/View Controller/EditFeedViewController.swift
@@ -1,0 +1,110 @@
+//
+//  EditFeedViewController.swift
+//  Presentation
+//
+//  Created by 유현진 on 6/26/24.
+//
+
+import UIKit
+import SnapKit
+import ReactorKit
+import RxSwift
+import RxCocoa
+import Domain
+
+public protocol EditFeedViewControllerDelegate: AnyObject {
+    func editedFeed()
+}
+
+public class EditFeedViewController: UIViewController {
+
+    public weak var delegate: EditFeedViewControllerDelegate?
+    
+    public var disposeBag: DisposeBag = DisposeBag()
+    
+    private lazy var confirmButton: UIButton = {
+        let button = UIButton()
+        button.setTitle("완료", for: .normal)
+        button.setTitleColor(.black, for: .normal)
+//        button.setTitleColor(.lightGray, for: .disabled)
+//        button.isEnabled = false
+        return button
+    }()
+    
+    private lazy var contentTextView: UITextView = {
+        let textView = UITextView()
+        
+        return UITextView()
+    }()
+    
+    public override func viewDidLoad() {
+        super.viewDidLoad()
+        configureUI()
+        configureNavigationBarItem()
+    }
+        
+    public override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        contentTextView.resignFirstResponder()
+    }
+    
+    public init(reactor: EditFeedReactor){
+        super.init(nibName: nil, bundle: nil)
+        self.reactor = reactor
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    deinit{
+        print("deinit EditFeedViewController")
+    }
+    
+    private func configureUI(){
+        self.title = "게시글 수정"
+        
+        self.view.addSubview(contentTextView)
+        
+        contentTextView.snp.makeConstraints { make in
+            make.top.equalTo(self.view.safeAreaLayoutGuide.snp.top)
+            make.bottom.equalTo(self.view.safeAreaLayoutGuide.snp.bottom)
+            make.left.right.equalToSuperview()
+        }
+    }
+    
+    private func configureNavigationBarItem(){
+        var barButtonItems: [UIBarButtonItem] = []
+        barButtonItems.append(UIBarButtonItem(customView: confirmButton))
+        self.navigationItem.setRightBarButtonItems(barButtonItems, animated: false)
+    }
+}
+
+extension EditFeedViewController: View{
+    
+    public func bind(reactor: EditFeedReactor) {
+        reactor.action.onNext(.fetchPost)
+        
+        reactor.state
+            .compactMap{$0.feed}
+            .bind{ [weak self] feed in
+                self?.contentTextView.text = feed.postContent
+            }.disposed(by: self.disposeBag)
+        
+        confirmButton.rx.tap
+            .map{ [weak self] _ in
+                self?.contentTextView.resignFirstResponder()
+                return Reactor.Action.editfeed(EditFeedRequestDTO(postContent: self?.contentTextView.text ?? "", dataType: 1, difficulty: "HARD"))
+            }.bind(to: reactor.action)
+            .disposed(by: self.disposeBag)
+        
+        reactor.state
+            .map{$0.editedFeed}
+            .filter{$0}
+            .bind{ [weak self] _ in
+                guard let self = self else { return }
+                self.delegate?.editedFeed()
+                self.navigationController?.popViewController(animated: true)
+            }.disposed(by: self.disposeBag)
+    }
+}

--- a/Projects/Presentation/Sources/Feed/Edit Feed/View Controller/EditFeedViewController.swift
+++ b/Projects/Presentation/Sources/Feed/Edit Feed/View Controller/EditFeedViewController.swift
@@ -26,8 +26,6 @@ public class EditFeedViewController: UIViewController {
         let button = UIButton()
         button.setTitle("완료", for: .normal)
         button.setTitleColor(.black, for: .normal)
-//        button.setTitleColor(.lightGray, for: .disabled)
-//        button.isEnabled = false
         return button
     }()
     
@@ -94,7 +92,7 @@ extension EditFeedViewController: View{
         confirmButton.rx.tap
             .map{ [weak self] _ in
                 self?.contentTextView.resignFirstResponder()
-                return Reactor.Action.editfeed(EditFeedRequestDTO(postContent: self?.contentTextView.text ?? "", dataType: 1, difficulty: "HARD"))
+                return Reactor.Action.editfeed(EditFeedRequestDTO(postContent: self?.contentTextView.text ?? "", dataType: 1, imageUrl: "")) // TODO: imageUrl 수정
             }.bind(to: reactor.action)
             .disposed(by: self.disposeBag)
         

--- a/Projects/Presentation/Sources/Feed/Feed/Model/FeedItem.swift
+++ b/Projects/Presentation/Sources/Feed/Feed/Model/FeedItem.swift
@@ -1,0 +1,21 @@
+//
+//  FeedItem.swift
+//  Presentation
+//
+//  Created by 유현진 on 6/26/24.
+//
+
+import Foundation
+import RxDataSources
+import Domain
+
+extension FeedModel: IdentifiableType, Equatable{
+
+    public var identity: Int {
+        return postId
+    }
+    
+    public static func == (lhs: FeedModel, rhs: FeedModel) -> Bool {
+        return lhs.postId == rhs.postId && lhs.isBookmarked == rhs.isBookmarked
+    }
+}

--- a/Projects/Presentation/Sources/Feed/Feed/Reactor/FeedReactor.swift
+++ b/Projects/Presentation/Sources/Feed/Feed/Reactor/FeedReactor.swift
@@ -15,6 +15,8 @@ final public class FeedReactor: Reactor{
     public enum Action{
         case fetchFeeds
         case refresh
+        case makeBookmark(BookmarkRequestDTO, Int)
+        case deleteBookmark(Int, Int)
     }
     
     public enum Mutation{
@@ -22,6 +24,7 @@ final public class FeedReactor: Reactor{
         case addFeeds([FeedModel], Int)
         case setRefreshing(Bool)
         case setLoading(Bool)
+        case updateBookmarked(Int, Bool)
     }
     
     public struct State{
@@ -45,7 +48,6 @@ final public class FeedReactor: Reactor{
         case .fetchFeeds:
             guard !currentState.isLoading else { return .empty()}
             guard currentState.pageNumber < currentState.totalPages else { return .empty()}
-            
             return Observable.concat([
                 Observable.just(Mutation.setLoading(true)),
                 self.feedUseCase.fetchFeeds(page: currentState.pageNumber)
@@ -63,6 +65,10 @@ final public class FeedReactor: Reactor{
                 Observable.just(Mutation.setLoading(false)),
                 Observable.just(Mutation.setRefreshing(false)),
             ])
+        case .makeBookmark(let bookmarkRequest, let index):
+            return feedUseCase.makeBookmark(post: bookmarkRequest).map{ _ in Mutation.updateBookmarked(index, true) }
+        case .deleteBookmark(let postId, let index):
+            return feedUseCase.deleteBookmark(postId: postId).map{_ in Mutation.updateBookmarked(index, false) }
         }
     }
     
@@ -70,10 +76,12 @@ final public class FeedReactor: Reactor{
         var newState = state
         switch mutation{
         case .setFeeds(let feeds, let totalPages):
+            print("set feed")
             newState.feeds = feeds
             newState.pageNumber = 1
             newState.totalPages = totalPages
         case .addFeeds(let feeds, let totalPages):
+            print("add feed")
             newState.feeds += feeds
             newState.pageNumber += 1
             newState.totalPages = totalPages
@@ -81,6 +89,8 @@ final public class FeedReactor: Reactor{
             newState.isRefreshing = value
         case .setLoading(let value):
             newState.isLoading = value
+        case .updateBookmarked(let index, let isBookmarked):
+            newState.feeds[index].isBookmarked = isBookmarked
         }
         return newState
     }

--- a/Projects/Presentation/Sources/Feed/Feed/Reactor/FeedReactor.swift
+++ b/Projects/Presentation/Sources/Feed/Feed/Reactor/FeedReactor.swift
@@ -76,12 +76,10 @@ final public class FeedReactor: Reactor{
         var newState = state
         switch mutation{
         case .setFeeds(let feeds, let totalPages):
-            print("set feed")
             newState.feeds = feeds
             newState.pageNumber = 1
             newState.totalPages = totalPages
         case .addFeeds(let feeds, let totalPages):
-            print("add feed")
             newState.feeds += feeds
             newState.pageNumber += 1
             newState.totalPages = totalPages

--- a/Projects/Presentation/Sources/Feed/Feed/ViewController/FeedViewController.swift
+++ b/Projects/Presentation/Sources/Feed/Feed/ViewController/FeedViewController.swift
@@ -157,7 +157,7 @@ extension FeedViewController: View{
                 guard let self = self else { return }
                 let model = self.dataSource[indexPath]
                 self.navigationItem.backBarButtonItem = UIBarButtonItem(title: "", style: .plain, target: self, action: nil)
-                self.coordinator?.showFeedDetail(postId: model.postId)
+                self.coordinator?.showFeedDetail(viewController: self, postId: model.postId)
             }.disposed(by: self.disposeBag)
         
         self.feedCollectionView.rx.contentOffset
@@ -193,5 +193,11 @@ extension FeedViewController: UICollectionViewDelegateFlowLayout{
     
     public func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, insetForSectionAt section: Int) -> UIEdgeInsets {
         return .init(top: 15, left: 15, bottom: 15, right: 15)
+    }
+}
+
+extension FeedViewController: FeedDetailViewControllerDelegate{
+    public func deleteFeed() {
+        reactor?.action.onNext(.refresh)
     }
 }

--- a/Projects/Presentation/Sources/Feed/Feed/ViewController/FeedViewController.swift
+++ b/Projects/Presentation/Sources/Feed/Feed/ViewController/FeedViewController.swift
@@ -177,6 +177,6 @@ extension FeedViewController: FeedDetailViewControllerDelegate{
 extension FeedViewController: PinterestLayoutDelegate {
     func collectionView(_ collectionView: UICollectionView, heightForPhotoAtIndexPath indexPath: IndexPath) -> CGFloat {
         let model = self.dataSource[indexPath]
-        return model.imageUrl == nil ? (collectionView.bounds.height - 38) / 3 : (collectionView.bounds.height - 38) / 2
+        return model.imageUrl == nil ? collectionView.bounds.height / 3 : collectionView.bounds.height / 2
     }
 }

--- a/Projects/Presentation/Sources/Feed/Feed/ViewController/PinterestLayout.swift
+++ b/Projects/Presentation/Sources/Feed/Feed/ViewController/PinterestLayout.swift
@@ -1,0 +1,79 @@
+//
+//  PinterestLayout.swift
+//  Presentation
+//
+//  Created by 유현진 on 6/26/24.
+//
+
+import UIKit
+
+protocol PinterestLayoutDelegate: AnyObject {
+    func collectionView(_ collectionView: UICollectionView, heightForPhotoAtIndexPath indexPath: IndexPath) -> CGFloat
+}
+
+class PinterestLayout: UICollectionViewLayout {
+    weak var delegate: PinterestLayoutDelegate?
+
+    private var numberOfColumns = 2
+    private var cellPadding: CGFloat = 5.0
+
+    private var cache: [UICollectionViewLayoutAttributes] = []
+    
+    private var contentHeight: CGFloat = 0
+    private var contentWidth: CGFloat {
+        guard let collectionView = collectionView else {
+            return 0
+        }
+        let insets = collectionView.contentInset
+        return collectionView.bounds.width - (insets.left + insets.right)
+    }
+    
+    override var collectionViewContentSize: CGSize {
+        return CGSize(width: contentWidth, height: contentHeight)
+    }
+
+    override func prepare() {
+        guard cache.isEmpty, let collectionView = collectionView else {
+            return
+        }
+
+        let columnWidth = contentWidth / CGFloat(numberOfColumns)
+        var xOffset: [CGFloat] = []
+        for column in 0 ..< numberOfColumns {
+            xOffset.append(CGFloat(column) * columnWidth)
+        }
+        var column = 0
+        var yOffset: [CGFloat] = .init(repeating: 0, count: numberOfColumns)
+
+        for item in 0 ..< collectionView.numberOfItems(inSection: 0) {
+            let indexPath = IndexPath(item: item, section: 0)
+            let photoHeight = delegate?.collectionView(collectionView, heightForPhotoAtIndexPath: indexPath) ?? 180
+            let height = cellPadding * 2 + photoHeight
+            let frame = CGRect(x: xOffset[column], y: yOffset[column], width: columnWidth, height: height)
+            let insetFrame = frame.insetBy(dx: cellPadding, dy: cellPadding)
+
+            let attributes = UICollectionViewLayoutAttributes(forCellWith: indexPath)
+            attributes.frame = insetFrame
+            cache.append(attributes)
+
+            contentHeight = max(contentHeight, frame.maxY)
+            yOffset[column] = yOffset[column] + height
+
+            column = column < (numberOfColumns - 1) ? (column + 1) : 0
+        }
+    }
+
+    override func layoutAttributesForElements(in rect: CGRect) -> [UICollectionViewLayoutAttributes]? {
+        var visibleLayoutAttributes: [UICollectionViewLayoutAttributes] = []
+        for attributes in cache {
+            if attributes.frame.intersects(rect) {
+                visibleLayoutAttributes.append(attributes)
+            }
+        }
+        return visibleLayoutAttributes
+    }
+
+    override func layoutAttributesForItem(at indexPath: IndexPath) -> UICollectionViewLayoutAttributes? {
+        return cache[indexPath.item]
+    }
+}

--- a/Projects/Presentation/Sources/Feed/Feed/Views/Cell/FeedCollectionViewCell.swift
+++ b/Projects/Presentation/Sources/Feed/Feed/Views/Cell/FeedCollectionViewCell.swift
@@ -100,6 +100,13 @@ class FeedCollectionViewCell: UICollectionViewCell {
         return label
     }()
     
+    private lazy var contentBackgroundView: UIView = {
+        let view = UIView()
+        view.isHidden = true
+        view.backgroundColor = UIColor.colorWithRGB(r: 0, g: 0, b: 0, alpha: 0.15)
+        return view
+    }()
+    
     override init(frame: CGRect) {
         super.init(frame: frame)
         configureUI()
@@ -126,10 +133,11 @@ class FeedCollectionViewCell: UICollectionViewCell {
         [likeImageView, likeCountLabel, commentImageView, commentCountLabel].forEach{
             self.buttonStackView.addArrangedSubview($0)
         }
-        
+        self.addSubview(contentBackgroundView)
         self.addSubview(buttonStackView)
         self.addSubview(mainContentLabel)
         self.addSubview(contentLabel)
+        
         
         thumbnailImageView.snp.makeConstraints { make in
             make.edges.equalToSuperview()
@@ -172,15 +180,31 @@ class FeedCollectionViewCell: UICollectionViewCell {
         }
         
         mainContentLabel.snp.makeConstraints { make in
-            make.bottom.equalTo(contentLabel.snp.top).offset(-10)
+            make.bottom.equalTo(contentLabel.snp.top).offset(-5)
             make.left.equalToSuperview().offset(10)
             make.right.equalToSuperview().offset(-10)
+        }
+        
+        contentBackgroundView.snp.makeConstraints { make in
+            make.top.equalTo(mainContentLabel.snp.top).offset(-5)
+            make.left.right.equalToSuperview()
+            make.bottom.equalToSuperview()
         }
     }
     
     func configureModel(model: FeedModel){
         if let url = model.imageUrl{
             self.thumbnailImageView.setImage(urlString: url)
+            setContentBackgrondView(isHidden: false)
+            setContentColor(color: .white)
+        }else{
+            if Bool.random(){
+                self.backgroundColor = .white
+                setContentColor(color: .black)
+            }else{
+                self.backgroundColor = UIColor.colorWithRGB(r: 34, g: 101, b: 201)
+                setContentColor(color: .white)
+            }
         }
         
         if let url = model.profileImageUrl{
@@ -193,64 +217,22 @@ class FeedCollectionViewCell: UICollectionViewCell {
         self.commentCountLabel.text = "\(model.commentCount)"
         self.mainContentLabel.text = model.mainData
         self.bookmarkButton.isSelected = model.isBookmarked
-        bindForColor()
     }
     
-    private func bindForColor() {
-        thumbnailImageView.rx.observe(UIImage.self, "image")
-            .compactMap { $0 }
-            .observe(on: MainScheduler.instance)
-            .flatMapLatest { [weak self] image -> Observable<(UIImage, CGRect, CGRect, CGRect, CGRect, CGRect, CGRect, CGRect)> in
-                guard let self = self else { return Observable.empty() }
-                
-                let nickNameLabelRect = self.convert(self.nickNameLabel.frame, to: self.thumbnailImageView)
-                let contentLabelRect = self.convert(self.contentLabel.frame, to: self.thumbnailImageView)
-                let kcalLabelRect = self.convert(self.mainContentLabel.frame, to: self.thumbnailImageView)
-                let likeCountLabelRect = self.convert(self.likeCountLabel.frame, to: self.thumbnailImageView)
-                let likeImageViewRect = self.convert(self.likeImageView.frame, to: self.thumbnailImageView)
-                let commentCountLabelRect = self.convert(self.commentCountLabel.frame, to: self.thumbnailImageView)
-                let commentImageViewRect = self.convert(self.commentImageView.frame, to: self.thumbnailImageView)
-                
-                return Observable.create { observer in
-                    DispatchQueue.global(qos: .userInitiated).async {
-                        observer.onNext((image, nickNameLabelRect, contentLabelRect, kcalLabelRect, likeCountLabelRect, likeImageViewRect, commentCountLabelRect, commentImageViewRect))
-                        observer.onCompleted()
-                    }
-                    return Disposables.create()
-                }
-            }
-            .observe(on: MainScheduler.instance)
-            .bind { [weak self] image, nickNameLabelRect, contentLabelRect, kcalLabelRect, likeCountLabelRect, likeImageViewRect, commentCountLabelRect, commentImageViewRect in
-                self?.updateTextColor(for: image, nickNameLabelRect: nickNameLabelRect, contentLabelRect: contentLabelRect, kcalLabelRect: kcalLabelRect, likeCountLabelRect: likeCountLabelRect, likeImageViewRect: likeImageViewRect, commentCountLabelRect: commentCountLabelRect, commentImageViewRect: commentImageViewRect)
-            }
-            .disposed(by: disposeBag)
+    private func setContentBackgrondView(isHidden: Bool){
+        self.contentBackgroundView.isHidden = isHidden
     }
 
-    private func updateTextColor(for image: UIImage, nickNameLabelRect: CGRect, contentLabelRect: CGRect, kcalLabelRect: CGRect, likeCountLabelRect: CGRect, likeImageViewRect: CGRect, commentCountLabelRect: CGRect, commentImageViewRect: CGRect) {
-        
-        DispatchQueue.global(qos: .userInitiated).async { [weak self] in
-            guard let self = self else { return }
-            
-            let averageColorForNickName = image.averageColor(in: nickNameLabelRect)
-            let averageColorForContent = image.averageColor(in: contentLabelRect)
-            let averageColorForKcal = image.averageColor(in: kcalLabelRect)
-            let averageColorForLikeCountLabel = image.averageColor(in: likeCountLabelRect)
-            let averageColorForLikeImageView = image.averageColor(in: likeImageViewRect)
-            let averageColorForCommentImageView = image.averageColor(in: commentImageViewRect)
-            let averageColorForCommentLabel = image.averageColor(in: commentCountLabelRect)
-            
-            DispatchQueue.main.async {
-                self.nickNameLabel.textColor = averageColorForNickName?.isDark ?? false ? .white : .black
-                self.contentLabel.textColor = averageColorForContent?.isDark ?? false ? .white : .black
-                self.mainContentLabel.textColor = averageColorForKcal?.isDark ?? false ? .white : .black
-                self.likeCountLabel.textColor = averageColorForLikeCountLabel?.isDark ?? false ? .white : .black
-                self.likeImageView.tintColor = averageColorForLikeImageView?.isDark ?? false ? .white : .black
-                self.commentImageView.tintColor = averageColorForCommentImageView?.isDark ?? false ? .white : .black
-                self.commentCountLabel.textColor = averageColorForCommentLabel?.isDark ?? false ? .white : .black
-            }
-        }
+    private func setContentColor(color: UIColor){
+        nickNameLabel.textColor = color
+        contentLabel.textColor = color
+        mainContentLabel.textColor = color
+        likeImageView.tintColor = color
+        likeCountLabel.textColor = color
+        commentImageView.tintColor = color
+        commentCountLabel.textColor = color
     }
-    
+
     private func resetModelForReuse(){
         disposeBag = DisposeBag()
         self.thumbnailImageView.kf.cancelDownloadTask()
@@ -265,7 +247,6 @@ class FeedCollectionViewCell: UICollectionViewCell {
         self.commentCountLabel.text = ""
         self.mainContentLabel.text = ""
         
-        nickNameLabel.textColor = .black
         contentLabel.textColor = .black
         mainContentLabel.textColor = .black
         likeImageView.tintColor = .black
@@ -273,6 +254,7 @@ class FeedCollectionViewCell: UICollectionViewCell {
         commentImageView.tintColor = .black
         commentCountLabel.textColor = .black
         bookmarkButton.isSelected = false
+        self.contentBackgroundView.isHidden = true
     }
     
     override func layoutSubviews() {

--- a/Projects/Presentation/Sources/Feed/Feed/Views/Cell/FeedCollectionViewCell.swift
+++ b/Projects/Presentation/Sources/Feed/Feed/Views/Cell/FeedCollectionViewCell.swift
@@ -86,6 +86,7 @@ class FeedCollectionViewCell: UICollectionViewCell {
     private lazy var mainContentLabel: UILabel = {
         let label = UILabel()
         label.text = "0kcal"
+        label.adjustsFontSizeToFitWidth = true
         label.font = UIFont.systemFont(ofSize: 36, weight: .bold)
         label.textColor = UIColor.colorWithRGB(r: 0, g: 0, b: 0)
         return label
@@ -172,7 +173,7 @@ class FeedCollectionViewCell: UICollectionViewCell {
         
         mainContentLabel.snp.makeConstraints { make in
             make.bottom.equalTo(contentLabel.snp.top).offset(-10)
-            make.left.equalToSuperview().offset(15)
+            make.left.equalToSuperview().offset(10)
             make.right.equalToSuperview().offset(-10)
         }
     }

--- a/Projects/Presentation/Sources/Feed/Feed/Views/Cell/FeedCollectionViewCell.swift
+++ b/Projects/Presentation/Sources/Feed/Feed/Views/Cell/FeedCollectionViewCell.swift
@@ -36,7 +36,7 @@ class FeedCollectionViewCell: UICollectionViewCell {
         return label
     }()
     
-    private lazy var bookmarkButton: UIButton = {
+    lazy var bookmarkButton: UIButton = {
         let button = UIButton()
         button.setImage(CommonAsset.bookmarkOutline.image, for: .normal)
         button.setImage(CommonAsset.bookmarkFilled.image, for: .selected)
@@ -102,7 +102,6 @@ class FeedCollectionViewCell: UICollectionViewCell {
     override init(frame: CGRect) {
         super.init(frame: frame)
         configureUI()
-        bindForColor()
     }
     
     required init?(coder: NSCoder) {
@@ -193,6 +192,7 @@ class FeedCollectionViewCell: UICollectionViewCell {
         self.commentCountLabel.text = "\(model.commentCount)"
         self.mainContentLabel.text = model.mainData
         self.bookmarkButton.isSelected = model.isBookmarked
+        bindForColor()
     }
     
     private func bindForColor() {
@@ -251,6 +251,7 @@ class FeedCollectionViewCell: UICollectionViewCell {
     }
     
     private func resetModelForReuse(){
+        disposeBag = DisposeBag()
         self.thumbnailImageView.kf.cancelDownloadTask()
         self.thumbnailImageView.image = nil
         
@@ -270,7 +271,7 @@ class FeedCollectionViewCell: UICollectionViewCell {
         likeCountLabel.textColor = .black
         commentImageView.tintColor = .black
         commentCountLabel.textColor = .black
-        bookmarkButton.isEnabled = false
+        bookmarkButton.isSelected = false
     }
     
     override func layoutSubviews() {

--- a/Projects/Presentation/Sources/Feed/FeedDetail/Reactor/FeedDetailReactor.swift
+++ b/Projects/Presentation/Sources/Feed/FeedDetail/Reactor/FeedDetailReactor.swift
@@ -19,6 +19,7 @@ public class FeedDetailReactor: Reactor{
         case makeBookmark(BookmarkRequestDTO)
         case deleteBookmark(Int)
         case deleteComment(CommentModel)
+        case deletePost(Int)
     }
     
     public enum Mutation{
@@ -30,6 +31,7 @@ public class FeedDetailReactor: Reactor{
         case setBookmark(Bool)
         case setLoading(Bool)
         case deleteComment
+        case deletePost
     }
     
     public struct State{
@@ -42,6 +44,7 @@ public class FeedDetailReactor: Reactor{
         var isLike: Bool = false
         var isBookmark: Bool = false
         var isLoading: Bool = false
+        var deletedPost: Bool = false
     }
     
     public var initialState: State
@@ -87,6 +90,8 @@ public class FeedDetailReactor: Reactor{
                 feedUseCase.fetchComment(postId: commentModel.postId, page: 0).map{ Mutation.setComment($0.0, $0.1) },
                 Observable.just(Mutation.setLoading(false)),
             ])
+        case .deletePost(let postId):
+            return feedUseCase.deletePost(postId: postId).map{ _ in Mutation.deletePost }
         }
     }
     
@@ -114,6 +119,9 @@ public class FeedDetailReactor: Reactor{
             newState.isBookmark = value
         case .deleteComment:
             break
+        case .deletePost:
+            newState.deletedPost = true
+            
         }
         return newState
     }

--- a/Projects/Presentation/Sources/Feed/FeedDetail/Reactor/FeedDetailReactor.swift
+++ b/Projects/Presentation/Sources/Feed/FeedDetail/Reactor/FeedDetailReactor.swift
@@ -37,6 +37,7 @@ public class FeedDetailReactor: Reactor{
     public struct State{
         var postId: Int
         var postModel: FeedDetailModel?
+        var isFetchedPost: Bool = false
         var commentModels: [CommentModel] = []
         var totalPages: Int = 1
         var pageNumber: Int = 0
@@ -58,7 +59,7 @@ public class FeedDetailReactor: Reactor{
     public func mutate(action: Action) -> Observable<Mutation> {
         switch action{
         case .fetchPost: return feedUseCase.fetchPost(postId: currentState.postId).map{ Mutation.setPost($0) }
-            
+    
         case .fetchComment:
             guard !currentState.isLoading else { return .empty()}
             guard currentState.pageNumber < currentState.totalPages else { return .empty()}
@@ -100,6 +101,7 @@ public class FeedDetailReactor: Reactor{
         switch mutation{
         case .setPost(let model):
             newState.postModel = model
+            newState.isFetchedPost = true
         case .setComment(let models, let totalPages):
             newState.commentModels = models
             newState.postModel?.commentCount = models.count
@@ -121,7 +123,6 @@ public class FeedDetailReactor: Reactor{
             break
         case .deletePost:
             newState.deletedPost = true
-            
         }
         return newState
     }

--- a/Projects/Presentation/Sources/Feed/FeedDetail/ViewController/FeedDetailViewController.swift
+++ b/Projects/Presentation/Sources/Feed/FeedDetail/ViewController/FeedDetailViewController.swift
@@ -407,18 +407,8 @@ extension FeedDetailViewController: View{
                 self?.touchUpNavigationBarOptionButton()
             }.disposed(by: self.disposeBag)
         
-        let scrollViewContentOffsetYObserver = scrollView.rx.contentOffset.map{$0.y}.asObservable()
-        
-        scrollViewContentOffsetYObserver
-            .distinctUntilChanged()
-            .filter{ [weak self] offset in
-                guard let self = self else { return false }
-                return offset + self.scrollView.frame.size.height + 100 > self.scrollView.contentSize.height
-            }.map{ _ in Reactor.Action.fetchComment}
-            .bind(to: reactor.action)
-            .disposed(by: self.disposeBag)
-        
-        scrollViewContentOffsetYObserver
+        scrollView.rx.contentOffset
+            .map{$0.y}
             .distinctUntilChanged()
             .bind{ [weak self] offset in
                 guard let self = self else { return }

--- a/Projects/Presentation/Sources/Feed/FeedDetail/ViewController/FeedDetailViewController.swift
+++ b/Projects/Presentation/Sources/Feed/FeedDetail/ViewController/FeedDetailViewController.swift
@@ -62,8 +62,20 @@ final public class FeedDetailViewController: UIViewController {
         return PostView()
     }()
     
+    private lazy var postRecordBreakLine: UIView = {
+        let view = UIView()
+        view.backgroundColor = UIColor.colorWithRGB(r: 232, g: 235, b: 237)
+        return view
+    }()
+    
     private lazy var recordView: FeedDetailRecordView = {
         return FeedDetailRecordView()
+    }()
+    
+    private lazy var recordCommentBreakLine: UIView = {
+        let view = UIView()
+        view.backgroundColor = UIColor.colorWithRGB(r: 232, g: 235, b: 237)
+        return view
     }()
     
     private lazy var commentTableView: UITableView = {
@@ -136,7 +148,9 @@ final public class FeedDetailViewController: UIViewController {
         self.view.backgroundColor = .systemBackground
         self.view.addSubview(scrollView)
         self.scrollView.addSubview(postView)
+        self.scrollView.addSubview(postRecordBreakLine)
         self.scrollView.addSubview(recordView)
+        self.scrollView.addSubview(recordCommentBreakLine)
         self.scrollView.addSubview(commentTableView)
         self.view.addSubview(commentInputView)
         
@@ -151,13 +165,25 @@ final public class FeedDetailViewController: UIViewController {
             make.width.equalToSuperview()
         }
         
+        postRecordBreakLine.snp.makeConstraints { make in
+            make.top.equalTo(postView.snp.bottom)
+            make.left.right.equalToSuperview()
+            make.height.equalTo(8)
+        }
+        
         recordView.snp.makeConstraints { make in
-            make.top.equalTo(postView.snp.bottom).offset(8)
+            make.top.equalTo(postRecordBreakLine.snp.bottom)
             make.left.right.width.equalToSuperview()
         }
         
+        recordCommentBreakLine.snp.makeConstraints { make in
+            make.top.equalTo(recordView.snp.bottom)
+            make.left.right.equalToSuperview()
+            make.height.equalTo(8)
+        }
+        
         commentTableView.snp.makeConstraints { make in
-            make.top.equalTo(recordView.snp.bottom).offset(8)
+            make.top.equalTo(recordCommentBreakLine.snp.bottom)
             make.left.right.width.equalToSuperview()
             make.bottom.equalToSuperview()
         }

--- a/Projects/Presentation/Sources/Feed/FeedDetail/ViewController/FeedDetailViewController.swift
+++ b/Projects/Presentation/Sources/Feed/FeedDetail/ViewController/FeedDetailViewController.swift
@@ -318,6 +318,17 @@ final public class FeedDetailViewController: UIViewController {
         }
         stickyViewHeight = stickyImageView.heightAnchor.constraint(equalToConstant: stickViewDefaultHeight)
         stickyViewHeight?.isActive = true
+        
+        let tapGesture = UITapGestureRecognizer()
+        stickyImageView.addGestureRecognizer(tapGesture)
+        stickyImageView.isUserInteractionEnabled = true
+        tapGesture.rx.event
+            .bind{ [weak self] _ in
+                guard let self = self else { return }
+                let vc = ThumbnailImageViewController(imageUrl: url)
+                vc.modalPresentationStyle = .fullScreen
+                self.present(vc, animated: true)
+            }.disposed(by: self.disposeBag)
     }
 }
 

--- a/Projects/Presentation/Sources/Feed/FeedDetail/ViewController/FeedDetailViewController.swift
+++ b/Projects/Presentation/Sources/Feed/FeedDetail/ViewController/FeedDetailViewController.swift
@@ -77,7 +77,7 @@ final public class FeedDetailViewController: UIViewController {
     }()
     
     // MARK: LifeCyecle
-    
+
     public override func viewDidLoad() {
         super.viewDidLoad()
         configureUI()
@@ -91,7 +91,6 @@ final public class FeedDetailViewController: UIViewController {
     public override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         configureNavigationBar()
-//        configureNavigationBarItem()
         self.tabBarController?.tabBar.isHidden = true
     }
     
@@ -336,8 +335,6 @@ extension FeedDetailViewController: View{
                 self.delegate?.deleteFeed()
                 self.navigationController?.popViewController(animated: true)
             }.disposed(by: self.disposeBag)
-        
-        
     }
 }
 

--- a/Projects/Presentation/Sources/Feed/FeedDetail/Views/FeedDetailRecordView.swift
+++ b/Projects/Presentation/Sources/Feed/FeedDetail/Views/FeedDetailRecordView.swift
@@ -119,10 +119,22 @@ final class FeedDetailRecordView: UIView {
         }
     }
     
-    func configureModel(time: Float, distance: Float, meanPace: Float, kcal: Float){
-        timeElementView.configureModel(title: "시간", value: Date().formatSecondsToHHMMSS(seconds: Int(time)))
+    func configureModel(time: Int, distance: Float, meanPace: Int, kcal: Int){
+        timeElementView.configureModel(title: "시간", value: Date().formatSecondsToHHMMSS(seconds: time))
         distanceElementView.configureModel(title: "거리", value: "\(distance) km")
-        meanPaceElementView.configureModel(title: "평균 페이스", value: "\(meanPace)")
-        kcalElementView.configureModel(title: "소모 칼로리", value: "\(Int(kcal)) kcal")
+        var meanPaceMin: String {
+            return meanPace / 60 != 0 ? "\(meanPace / 60)’ " : ""
+        }
+        var meanPaceSec: String {
+            if meanPace % 60 == 0 {
+                return "00”"
+            }else if meanPace % 60 < 10{
+                return "0\(meanPace % 60)”"
+            }else{
+                return "\(meanPace % 60)”"
+            }
+        }
+        meanPaceElementView.configureModel(title: "평균 페이스", value: "\(meanPaceMin)\(meanPaceSec)")
+        kcalElementView.configureModel(title: "소모 칼로리", value: "\(kcal) kcal")
     }
 }

--- a/Projects/Presentation/Sources/Feed/FeedDetail/Views/PostView.swift
+++ b/Projects/Presentation/Sources/Feed/FeedDetail/Views/PostView.swift
@@ -151,10 +151,12 @@ final class PostView: UIView {
     }
     
     func configureModel(model: FeedDetailModel){
-//        profileImageView
+        if let profileImageUrl = model.profileImageUrl{
+            profileImageView.setImage(urlString: profileImageUrl)
+        }
         nickNameLabel.text = model.nickname ?? "러닝하이"
         contentLabel.text = model.postContent
-        levelLabel.text = "Lv\(model.level)"
+        levelLabel.text = "Lv.\(model.level)"
         dateLabel.text = Date().createDateToString(createDate: model.createDate)
         likeCountLabel.text = "\(model.likeCount)"
         commentCountLabel.text = "\(model.commentCount)"

--- a/Projects/Presentation/Sources/Feed/ImageViewer/ThumbnailImageViewController.swift
+++ b/Projects/Presentation/Sources/Feed/ImageViewer/ThumbnailImageViewController.swift
@@ -1,0 +1,146 @@
+//
+//  ThumbnailImageViewController.swift
+//  Presentation
+//
+//  Created by 유현진 on 6/30/24.
+//
+
+import UIKit
+import Common
+import SnapKit
+import RxSwift
+import RxCocoa
+
+class ThumbnailImageViewController: UIViewController {
+
+    private var disposeBag: DisposeBag = DisposeBag()
+    
+    private lazy var cancelButton: UIButton = {
+        let button = UIButton()
+        return button
+    }()
+    
+    private lazy var cancelButtonImageView: UIImageView = {
+        let imageView = UIImageView()
+        imageView.image = CommonAsset.xOutline.image.withRenderingMode(.alwaysTemplate)
+        imageView.tintColor = .white
+        return imageView
+    }()
+    
+    private lazy var scrollView: UIScrollView = {
+        let scrollView = UIScrollView()
+        scrollView.maximumZoomScale = 3.0
+        scrollView.minimumZoomScale = 1.0
+        scrollView.bouncesZoom = true
+        scrollView.backgroundColor = .black
+        scrollView.showsHorizontalScrollIndicator = false
+        scrollView.showsVerticalScrollIndicator = false
+        return scrollView
+    }()
+    
+    private lazy var thumbnailImageView: UIImageView = {
+        let imageView = UIImageView()
+        imageView.contentMode = .scaleAspectFit
+        return imageView
+    }()
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        configureUI()
+        bind()
+        // Do any additional setup after loading the view.
+    }
+    
+    init(imageUrl: String){
+        super.init(nibName: nil, bundle: nil)
+        setThumbnailImageView(imageUrl: imageUrl)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    private func configureUI(){
+        self.view.addSubview(scrollView)
+        scrollView.addSubview(thumbnailImageView)
+        self.view.addSubview(cancelButton)
+        self.cancelButton.addSubview(cancelButtonImageView)
+        
+        cancelButton.snp.makeConstraints { make in
+            make.top.equalToSuperview().offset(50)
+            make.left.equalToSuperview().offset(10)
+            make.width.height.equalTo(45)
+        }
+        
+        cancelButtonImageView.snp.makeConstraints { make in
+            make.edges.equalToSuperview().inset(5)
+        }
+        
+        scrollView.snp.makeConstraints { make in
+            make.edges.equalToSuperview()
+        }
+        
+        thumbnailImageView.snp.makeConstraints { make in
+            make.width.height.equalToSuperview()
+        }
+    }
+    
+    private func setThumbnailImageView(imageUrl: String){
+        self.thumbnailImageView.setImage(urlString: imageUrl)
+    }
+
+    private func bind(){
+        cancelButton.rx.tap
+            .bind{ [weak self] _ in
+                self?.dismiss(animated: true)
+            }.disposed(by: self.disposeBag)
+        
+        scrollView.rx.setDelegate(self)
+            .disposed(by: self.disposeBag)
+        
+        scrollView.rx.didScroll
+            .bind{ [weak self] _ in
+                guard let self = self else {return}
+                guard self.scrollView.zoomScale <= 1.0 else { return }
+                guard self.scrollView.zoomScale >= 3.0 else { return }
+            }.disposed(by: self.disposeBag)
+        
+        let panGesture = UIPanGestureRecognizer()
+        scrollView.addGestureRecognizer(panGesture)
+    
+        panGesture.rx.event
+            .bind{ [weak self] gesture in
+                self?.handlePanGesture(gesture: gesture)
+            }.disposed(by: self.disposeBag)
+    }
+    
+    private func handlePanGesture(gesture: UIPanGestureRecognizer){
+        let translation = gesture.translation(in: scrollView) // 터치한 시작 지점으로부터 이동거리
+        
+        switch gesture.state{
+        case .changed:
+            if scrollView.zoomScale == 1.0{
+                if translation.y > 0 {
+                    self.thumbnailImageView.center = .init(x: self.view.bounds.size.width/2, y: self.view.bounds.size.height/2 + translation.y)
+                }
+                if translation.y > 150 {
+                    self.dismiss(animated: true, completion: nil)
+                }
+            }
+        case .ended, .cancelled:
+            if scrollView.zoomScale == 1.0{
+                UIView.animate(withDuration: 0.3) {
+                    self.thumbnailImageView.center = .init(x: self.view.bounds.size.width/2, y: self.view.bounds.size.height/2)
+                }
+            }
+        default:
+            break
+        }
+    }
+}
+
+extension ThumbnailImageViewController: UIScrollViewDelegate{
+    func viewForZooming(in scrollView: UIScrollView) -> UIView? {
+        return thumbnailImageView
+    }
+}


### PR DESCRIPTION
1. 피드 그리드 기능 개선
2. 피드 북마크 버튼
3-1. 피드 셀 동적 글자색 삭제
3-2. 피드 백그라운드 뷰 생성
        3-2-1. 사진이 있는 피드
             백그라운드 뷰
                - 글자색 흰색
        3-2-2. 사진이 없는 피드
             셀 배경색 랜덤
                - 파란 색인 경우 글자 색 흰색
                - 흰 색인 경우 글자 색 검은색
4. 내 피드 삭제
5. 피드 상세 스티키 뷰
6. 피드 상세 스티키 뷰 클릭 시 전체보기
    6-1. 사진 확대 축소
    6-2. 하단 스와이프 시 창 닫기
7. 댓글 페이징 삭제
8. 댓글 0개일 경우 안내 뷰 추가
9. 댓글 작성 후 텍스트 입력창 레이아웃 초기화 안 되는 점 수정
10. 댓글 삭제
11. 댓글 신고
12. 게시글 수정 API만 구현(테스트 UI)
