### PR TITLE
fix: api 서버 도메인 수정

### DIFF
--- a/Projects/Coordinator/Sources/Auth/AuthService.swift
+++ b/Projects/Coordinator/Sources/Auth/AuthService.swift
@@ -20,9 +20,9 @@ extension AuthService: TargetType{
         switch self {
         case .isValidAccessToken,
              .isValidRefreshToken :
-            return .init(string: "https://runninghi.store/api/v1")!
+            return .init(string: "https://runninghi.kr/api/v1")!
         case .isReviewerVersion:
-            return .init(string: "https://runninghi.store")!
+            return .init(string: "https://runninghi.kr")!
         }
     }
     

--- a/Projects/Data/Sources/Network/Announce/AnnounceService.swift
+++ b/Projects/Data/Sources/Network/Announce/AnnounceService.swift
@@ -18,7 +18,7 @@ public enum AnnounceService{
 
 extension AnnounceService: TargetType{
     public var baseURL: URL {
-        return .init(string: "https://runninghi.store/api/v1")!
+        return .init(string: "https://runninghi.kr/api/v1")!
     }
     
     public var accessToken: String{

--- a/Projects/Data/Sources/Network/Challenge/ChallengeService.swift
+++ b/Projects/Data/Sources/Network/Challenge/ChallengeService.swift
@@ -21,7 +21,7 @@ public enum ChallengeService{
 extension ChallengeService: TargetType{
     
     public var baseURL: URL {
-        return .init(string: "https://runninghi.store/api/v1")!
+        return .init(string: "https://runninghi.kr/api/v1")!
     }
     
     public var accessToken: String{

--- a/Projects/Data/Sources/Network/Feed/FeedService.swift
+++ b/Projects/Data/Sources/Network/Feed/FeedService.swift
@@ -40,7 +40,7 @@ extension FeedService: TargetType{
         case .fetchGPSData(let url):
             return .init(string: url)!
         default:
-            return .init(string: "https://runninghi.store/api/v1")!
+            return .init(string: "https://runninghi.kr/api/v1")!
         }
         
     }

--- a/Projects/Data/Sources/Network/Login/LoginService.swift
+++ b/Projects/Data/Sources/Network/Login/LoginService.swift
@@ -20,9 +20,9 @@ extension LoginService: TargetType{
     public var baseURL: URL{
         switch self {
         case .loginFromReviewer:
-            return .init(string: "https://runninghi.store")!
+            return .init(string: "https://runninghi.kr")!
         default:
-            return .init(string: "https://runninghi.store/api/v1")!
+            return .init(string: "https://runninghi.kr/api/v1")!
         }
     }
     

--- a/Projects/Data/Sources/Network/My/MyService.swift
+++ b/Projects/Data/Sources/Network/My/MyService.swift
@@ -28,7 +28,7 @@ public enum MyService{
 
 extension MyService: TargetType{
     public var baseURL: URL {
-        return .init(string: "https://runninghi.store/api/v1")!
+        return .init(string: "https://runninghi.kr/api/v1")!
     }
     
     public var accessToken: String{

--- a/Projects/Data/Sources/Network/Record/RecordService.swift
+++ b/Projects/Data/Sources/Network/Record/RecordService.swift
@@ -23,7 +23,7 @@ extension RecordService: TargetType {
         case .fetchGPSData(let url):
             return .init(string: url)!
         default:
-            return .init(string: "https://runninghi.store/api/v1")!
+            return .init(string: "https:///api/v1")!
         }
     }
     

--- a/Projects/Data/Sources/Network/Running/RunningService.swift
+++ b/Projects/Data/Sources/Network/Running/RunningService.swift
@@ -16,7 +16,7 @@ public enum RunningService {
 
 extension RunningService: TargetType {
     public var baseURL: URL {
-        return .init(string: "https://runninghi.store/api/v1")!
+        return .init(string: "https://runninghi.kr/api/v1")!
     }
     
     public var accessToken: String {


### PR DESCRIPTION
# 🚀 도메인 주소 변경 (runninghi.store → runninghi.kr)

## 📝 개요
백엔드 서버 도메인이 `runninghi.store`에서 `runninghi.kr`로 변경됨에 따라 iOS 앱의 API 호출 URL을 업데이트했습니다.

## ✨ 변경 사항
- 모든 네트워크 서비스 클래스에서 하드코딩된 도메인 주소를 업데이트:
  - AuthService.swift
  -  LoginService.swift
  - RunningService.swift
  -  AnnounceService.swift
  -  RecordService.swift
  -  FeedService.swift
  -  MyService.swift
  -  ChallengeService.swift

## 🔍 영향 범위
URL 변경만 수행했으므로 앱의 비즈니스 로직에는 영향 없을 것 같습니다.
사용자 경험 및 기능에 변화 없음

## 💡 기타 고려 사항
- SSL 인증서가 새 도메인에서 유효함을 확인
- 이전 도메인(runninghi.store)은 당분간 유지되어 점진적 전환 가능

## 👀 리뷰어를 위한 참고 사항
도메인 변경만 진행했으며, 코드 구조나 로직은 변경하지 않았습니다.